### PR TITLE
Pcap program options

### DIFF
--- a/flowpath/CMakeLists.txt
+++ b/flowpath/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 
 # Allow includes to find from headers from this dir.
 include_directories(.)
+include_directories(..)
 
 # Applications.
 #add_subdirectory(apps)

--- a/flowpath/drivers/pcap/CMakeLists.txt
+++ b/flowpath/drivers/pcap/CMakeLists.txt
@@ -14,3 +14,8 @@ target_link_libraries(caida-pcap flowpath-rt flowpath-applib ${PCAP_LIBRARY} ${C
 #  target_link_libraries(pcap-driver-odp flowpath-rt flowpath-applib ${CMAKE_DL_LIBS})
 #endif()
 
+# Require Boost C++ Libraries.
+find_package(Boost 1.55.0 COMPONENTS program_options REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+target_link_libraries(caida-pcap ${Boost_LIBRARIES})
+


### PR DESCRIPTION
Added program options using boost library. This is extensible and could in the future include verbosity options like Luke and I talked about.

```
Usage: ./caida-pcap [options] inputA [inputB]
Available options:
  -h [ --help ]                         Display this message
  -l [ --log-file ] arg               The name of the log file
  -o [ --output-file ] arg        The name of the trace file
  -L [ --list ]                         Indicates that the input file contains a list of pcap files to read
```
